### PR TITLE
postgresのメジャーアップデートをrenovateの対象外にする

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,19 @@
 {
   "extends": [
     "github>dev-hato/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "postgres"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
postgresはMisskey準拠にしたいので、renovateによるメジャーアップデートの対象外にします。