### PR TITLE
通報取得数の型変換修正

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ func main() {
 		logrus.Fatal(err.Error())
 	}
 
-	userReportsLimit, err := strconv.ParseUint(os.Getenv("MISSKEY_USER_REPORTS_LIMIT"), 10, 64)
+	userReportsLimit, err := strconv.ParseUint(os.Getenv("MISSKEY_USER_REPORTS_LIMIT"), 10, 32)
 	if err != nil {
 		logrus.Fatal(err.Error())
 	}


### PR DESCRIPTION
https://codeql.github.com/codeql-query-help/go/go-incorrect-integer-conversion/

通報取得数 ( `Limit` ) は `uint` 型で32ビットになりうるので、型変換時の `bitSize` を32ビットにします。