### PR TITLE
textlint-rule-preset-ja-technical-writingアップデート

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Misskeyサーバーに対する通報をDiscordサーバーに流すプログラ
 
 #### 共通
 
-1. `cp .env.example .env` を実行して `.env` を作成します。
-2. `.env` 内のTODOコメントに従って設定します。
+1. `cp .env.example .env` を実行して `.env` を作成する。
+2. `.env` 内のTODOコメントに従って設定する。
 
 #### 開発環境
 
@@ -25,7 +25,7 @@ docker compose -f docker-compose.yml -f dev.base.docker-compose.yml -f dev.docke
 ```
 
 #### 本番環境
-PostgreSQLのDBを別途用意したうえで以下を実行します。
+PostgreSQLのDBを別途用意したうえで以下を実行する。
 
 ```sh
 export TAG_NAME=$(git symbolic-ref --short HEAD | sed -e "s:/:-:g" | sed -e "s/^main$/latest/g")

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet": "1.0.1",
         "textlint-rule-prefer-tari-tari": "1.0.3",
         "textlint-rule-preset-ja-spacing": "2.3.0",
-        "textlint-rule-preset-ja-technical-writing": "9.0.0",
+        "textlint-rule-preset-ja-technical-writing": "10.0.1",
         "textlint-rule-terminology": "4.0.1"
       }
     },
@@ -4724,56 +4724,13 @@
       }
     },
     "node_modules/textlint-rule-no-mix-dearu-desumasu": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/textlint-rule-no-mix-dearu-desumasu/-/textlint-rule-no-mix-dearu-desumasu-5.0.0.tgz",
-      "integrity": "sha512-fBNWXBUeP9xuxZYjNqm3PQDsHStYPxpkJaLwTvbNQEZ6rpC1dHsHwLujYtuAQVuvrfxxU6J4jtepP61rhjPA8g==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-no-mix-dearu-desumasu/-/textlint-rule-no-mix-dearu-desumasu-6.0.2.tgz",
+      "integrity": "sha512-h/Vs6qltBlkm7bmKT2rtJ6jZriNV3uTr5fxKuPMBUHVUMnAuQvz3lI7oFrGC10Pxny+Ofng5fbLiYntHq/ymaA==",
       "dev": true,
       "dependencies": {
-        "analyze-desumasu-dearu": "^5.0.0",
-        "textlint-rule-helper": "^2.0.0",
-        "unist-util-visit": "^3.0.0"
-      }
-    },
-    "node_modules/textlint-rule-no-mix-dearu-desumasu/node_modules/unist-util-is": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
-      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
-      "dev": true,
-      "dependencies": {
-        "@types/unist": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/textlint-rule-no-mix-dearu-desumasu/node_modules/unist-util-visit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-3.1.0.tgz",
-      "integrity": "sha512-Szoh+R/Ll68QWAyQyZZpQzZQm2UPbxibDvaY8Xc9SUtYgPsDzx5AWSk++UUt2hJuow8mvwR+rG+LQLw+KsuAKA==",
-      "dev": true,
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^5.0.0",
-        "unist-util-visit-parents": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/textlint-rule-no-mix-dearu-desumasu/node_modules/unist-util-visit-parents": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-4.1.1.tgz",
-      "integrity": "sha512-1xAFJXAKpnnJl8G7K5KgU7FY55y3GcLIXqkzUj5QF/QVP7biUm0K0O2oqVkYsdjzJKifYeWn9+o6piAK2hGSHw==",
-      "dev": true,
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
+        "analyze-desumasu-dearu": "^5.0.1",
+        "textlint-rule-helper": "^2.3.1"
       }
     },
     "node_modules/textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet": {
@@ -4836,9 +4793,9 @@
       }
     },
     "node_modules/textlint-rule-preset-ja-technical-writing": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/textlint-rule-preset-ja-technical-writing/-/textlint-rule-preset-ja-technical-writing-9.0.0.tgz",
-      "integrity": "sha512-1dbqEkIaYG57lDE5pdynF9F/8lPhtxp9/CzgvIAeHa3wpIwFsGf6OKUP2cEONeYlyeye1WpAwXVzMEDkp525sA==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/textlint-rule-preset-ja-technical-writing/-/textlint-rule-preset-ja-technical-writing-10.0.1.tgz",
+      "integrity": "sha512-GC7sUPsn65UOZcBQ+SLvt3RRmGcm3Fb8t/o8/hD/zyRr1NpYYNrtte0HckVnCPH3TD8zbMt4mov2nlnfA8f7gg==",
       "dev": true,
       "dependencies": {
         "@textlint-rule/textlint-rule-no-invalid-control-character": "^2.0.0",
@@ -4860,7 +4817,7 @@
         "textlint-rule-no-dropping-the-ra": "^3.0.0",
         "textlint-rule-no-exclamation-question-mark": "^1.1.0",
         "textlint-rule-no-hankaku-kana": "^2.0.1",
-        "textlint-rule-no-mix-dearu-desumasu": "^5.0.0",
+        "textlint-rule-no-mix-dearu-desumasu": "^6.0.0",
         "textlint-rule-no-nfd": "^2.0.2",
         "textlint-rule-no-zero-width-spaces": "^1.0.1",
         "textlint-rule-preset-jtf-style": "^2.3.13",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet": "1.0.1",
     "textlint-rule-prefer-tari-tari": "1.0.3",
     "textlint-rule-preset-ja-spacing": "2.3.0",
-    "textlint-rule-preset-ja-technical-writing": "9.0.0",
+    "textlint-rule-preset-ja-technical-writing": "10.0.1",
     "textlint-rule-terminology": "4.0.1"
   }
 }


### PR DESCRIPTION
https://github.com/dev-hato/misskey-abuse-user-report-notifier/pull/40 をベースに `textlint-rule-preset-ja-technical-writing` をアップデートします。
合わせて、READMEをである調に統一しています。