### PR TITLE
github.com/air-verse/air アップデート

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG TARGETPLATFORM
 WORKDIR /go/app
 COPY go.mod go.sum ./
 COPY tools.go ./
-RUN go install github.com/cosmtrek/air
+RUN go install github.com/air-verse/air
 COPY . .
 RUN mapfile -t PLATFORM < <(echo "${TARGETPLATFORM}" | tr '/' ' ') \
     && CGO_ENABLED=0 GOOS=linux GOARCH=${PLATFORM[2]} go build -o ./app \

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.22.3
 require (
 	entgo.io/ent v0.13.1
 	github.com/bwmarrin/discordgo v0.28.1
-	github.com/cosmtrek/air v1.52.2
+	github.com/air-verse/air v1.52.2
 	github.com/lib/pq v1.10.9
 	github.com/sirupsen/logrus v1.9.3
 	github.com/yitsushi/go-misskey v1.1.6

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.22.3
 require (
 	entgo.io/ent v0.13.1
 	github.com/bwmarrin/discordgo v0.28.1
-	github.com/cosmtrek/air v1.52.1
+	github.com/cosmtrek/air v1.52.2
 	github.com/lib/pq v1.10.9
 	github.com/sirupsen/logrus v1.9.3
 	github.com/yitsushi/go-misskey v1.1.6

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ toolchain go1.22.3
 
 require (
 	entgo.io/ent v0.13.1
-	github.com/bwmarrin/discordgo v0.28.1
 	github.com/air-verse/air v1.52.2
+	github.com/bwmarrin/discordgo v0.28.1
 	github.com/lib/pq v1.10.9
 	github.com/sirupsen/logrus v1.9.3
 	github.com/yitsushi/go-misskey v1.1.6

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20O
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
+github.com/air-verse/air v1.52.2 h1:z5v9TSdGacd5fheA4+3CRMtWdMA5JspM6ju04tlrAvw=
+github.com/air-verse/air v1.52.2/go.mod h1:1xd2oyYArpkaeJ0IXNYj+GYLwdfPfID+cAh7cu6XTlI=
 github.com/alecthomas/chroma/v2 v2.13.0 h1:VP72+99Fb2zEcYM0MeaWJmV+xQvz5v5cxRHd+ooU1lI=
 github.com/alecthomas/chroma/v2 v2.13.0/go.mod h1:BUGjjsD+ndS6eX37YgTchSEG+Jg9Jv1GiZs9sqPqztk=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
@@ -51,8 +53,6 @@ github.com/cli/safeexec v1.0.0/go.mod h1:Z/D4tTN8Vs5gXYHDCbaM1S/anmEDnJb1iW0+EJ5
 github.com/cli/safeexec v1.0.1 h1:e/C79PbXF4yYTN/wauC4tviMxEV13BwljGj0N9j+N00=
 github.com/cli/safeexec v1.0.1/go.mod h1:Z/D4tTN8Vs5gXYHDCbaM1S/anmEDnJb1iW0+EJ5zx3Q=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cosmtrek/air v1.52.1 h1:R+BiGX9tWJ36ENM0ZroaRkagKgIlCmy+8IGTvMyoDV4=
-github.com/cosmtrek/air v1.52.1/go.mod h1:xILtq8JGIYwe++r/ib4PdhubiuKBmE1vutC49E+5A78=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.21 h1:1/QdRyBaHHJP61QkWMXlOIBfsgdDeeKfK8SYVUWJKf0=
 github.com/creack/pty v1.1.21/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=

--- a/tools.go
+++ b/tools.go
@@ -4,6 +4,6 @@
 package tools
 
 import (
-	_ "github.com/cosmtrek/air"          //nolint:typecheck
+	_ "github.com/air-verse/air"         //nolint:typecheck
 	_ "golang.org/x/tools/cmd/goimports" //nolint:typecheck
 )


### PR DESCRIPTION
https://github.com/dev-hato/misskey-abuse-user-report-notifier/pull/198 をベースに `github.com/air-verse/air` をアップデートします。
GitHubリポジトリのorg名が変更されているようなので、それに合わせて修正を加えています。